### PR TITLE
MCC-3: Full re-factor of king movement

### DIFF
--- a/monte_carlo_chess/Pieces/king.py
+++ b/monte_carlo_chess/Pieces/king.py
@@ -8,14 +8,17 @@ class King(Piece):
 
     def isValidMove(self, curr_posn, new_posn, board):
 
-        if not is_on_board(new_posn) or same_colour_in_spot(new_posn):
+        if not utility.is_on_board(new_posn) or utility.same_colour_in_spot(new_posn)
+            or self.can_be_attacked(new_posn, board):
             return False
 
+        # position changes
+        delta_x = abs(new_posn[1] - self.curr_posn[1])
+        delta_y = abs(new_posn[0] - self.curr_posn[0])
+
         # move of distance one
-        if (
-            abs(new_posn[1] - self.curr_posn[1]) + abs(new_posn[0] - self.curr_posn[0])
-            == 1
-        ):
+        if (delta_x + delta_y <= 2) and (delta_x == 1 or delta_y == 1) and
+            not utility.same_colour_in_spot(new_posn):
             return True
 
         # castling
@@ -37,18 +40,23 @@ class King(Piece):
             return False
 
         for col in range(
-            min(curr_posn[1], target_rook_posn[1]) + 1,
-            max(curr_posn[1], target_rook_posn[1]) - 1,
+            min(curr_posn[1], target_rook_posn[1]),
+            max(curr_posn[1], target_rook_posn[1]) + 1,
         ):
-            # piece in the way
-            if board[(new_posn[0], col)] or can_be_attacked((new_posn[0], col), board):
+            """special case for col = 1, since long castling has one spot that won't be occupied
+            and we don't care if it's being attacked"""
+            if col != 1 and self.can_be_attacked((new_posn[0], col), board):
+                return False
+
+            # piece in-between king and rook
+            if (col != curr_posn[1] and col != target_rook_posn[1]) and board[(new_posn[0], col)]:
                 return False
 
         return True
 
         def move(self, curr_posn, new_posn, board):
 
-            if vaildMove(self, curr_posn, new_posn, board):
+            if self.isValidMove(self, curr_posn, new_posn, board):
                 # is castling
                 if (
                     abs(new_posn[1] - self.curr_posn[1])
@@ -60,9 +68,11 @@ class King(Piece):
                     elif new_posn[1] == 6:
                         target_rook_posn = [new_posn[0], 7]
                     else:
+                        #should never happen
                         raise BadMoveError("Castling but King is not correct position")
 
                     if not board[target_rook_posn]:
+                        #should never happen
                         raise BadMoveError("Castling but Rook is not correct position")
 
                     if not board[target_rook_posn].move(
@@ -83,7 +93,7 @@ class King(Piece):
                 for col in range(BOARD_SIZE):
                     if (
                         board[(row, col)] and board[(row, col)].colour == "B"
-                        if val == "W"
+                        if self.colour == "W"
                         else "W"
                         and board[(row, col)].isValidMove((row, col), posn, board)
                     ):


### PR DESCRIPTION
Modified the standard move (non-castle), made sure king was not
moving into check, and modified the castling so we know the king is
not in check, the rook cannot be captured, and the pieces that the
king and rook will land on are not being attacked.